### PR TITLE
バリデーションとビュー調整

### DIFF
--- a/app/assets/stylesheets/_step2.scss
+++ b/app/assets/stylesheets/_step2.scss
@@ -93,9 +93,6 @@
       margin: 0 auto;
       width: 50%;
       padding: 20px 0;
-      &-titles{
-        height: 100px;
-      }
     }
     &-footer{
       height: calc(100vh - 620px);
@@ -108,7 +105,6 @@
       margin: 0 auto;
     }
     &-texts{
-      height: 50px;
       width: 100%;
     }
     &-text{
@@ -146,7 +142,6 @@
       }
     }
     &-required{
-      height: 20px;
       width: 30px;
       color: #ffffff;
       line-height: 20px;
@@ -157,7 +152,6 @@
       border-radius: 3px;
     }
     &-confirmation{
-      height: 20px;
       font-weight: bolder;
       margin-top: 20px;
       color: #3D3D3D;

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,6 @@ class Users::SessionsController < Devise::SessionsController
   # POST /resource/sign_in
   def create
     @user = User.new(configure_sign_in_params)
-    binding.pry
     if @user[:agreement].blank?
       render 'new' unless @user.valid?
     else

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -32,9 +32,9 @@
           = f.check_box :agreement, {class: "login-block-main-lists-robo-check"}, 1, nil
           .login-block-main-lists-robo-write
             私はロボットではありません
-        - if @user.errors[:password].any?
+        - if @user.errors[:agreement].any?
           %ul.error-text
-            - @user.errors[:password].each do |message|
+            - @user.errors[:agreement].each do |message|
               %li= message
         .login-block-main-lists-box
           = f.submit "ログイン", class:"login-block-main-lists-box-btn"

--- a/app/views/signup/user_registration.html.haml
+++ b/app/views/signup/user_registration.html.haml
@@ -57,14 +57,14 @@
                 必須
             .step2-block-texts
               = f.password_field :password, class:'step2-block-text', autofocus: true, placeholder: "7文字以上"
-            - if @user.errors[:password].any?
-              %ul.error-text
-                - @user.errors[:password].each do |message|
-                  %li= message
-            .step2-block-chk-box
-              = check_box :group, :user_ids, {class: "step2-block-chk-box-check"}, true, false
-              .step2-block-chk-box-message
-                パスワードを表示する
+          - if @user.errors[:password].any?
+            %ul.error-text
+              - @user.errors[:password].each do |message|
+                %li= message
+          .step2-block-chk-box
+            = check_box :group, :user_ids, {class: "step2-block-chk-box-check"}, true, false
+            .step2-block-chk-box-message
+              パスワードを表示する
           .step2-block-confirmation
             本人確認
           .step2-block-confirmation__details


### PR DESCRIPTION
＃What
バリデーションとビュー調整

#Why
エラーメッセージの追加でビュー崩れを起こしたため
サインイン画面にバリデーションをかけ、チェックボックスにチェックしないとサインインできないようにした