### PR TITLE
Limit number of items on top page

### DIFF
--- a/app/assets/javascripts/item/carousel.js
+++ b/app/assets/javascripts/item/carousel.js
@@ -1,0 +1,17 @@
+$(function(){
+  var timerId;
+  $('.owl-dot').eq(0).addClass('active')
+
+  $('.owl-dot').hover(function(){
+    if($(this).not('active')){
+      console.log("OK")
+      $(this).addClass('active').siblings('.owl-dot').removeClass('active');
+      var index = $(".owl-dots").children().index(this);
+      $(".owl-stage").children().eq(index).addClass('active').siblings(".owl-item").removeClass('active');
+      timerId = setTimeout(function(){
+        var stage_length = index * -300
+        $(".owl-stage").css("left", `${stage_length}px` )
+      }, 300)
+    }
+  })
+})

--- a/app/assets/javascripts/item/category.js
+++ b/app/assets/javascripts/item/category.js
@@ -8,8 +8,101 @@ $(function(){
     $('#grandchild-select').append(child_option);
   } 
   // 商品の編集ページ用js
-  if (window.location.href.match(/\/items\/\d+\/edit/)){
+  if (window.location.href.match(/\/items\/new/)){
+  
+      $("#brand-wrap").hide();
+      $("#child-wrap").hide();
+      $("#grandchild-wrap").hide();
+      $("#delivery-method-wrap").hide();
+  
+  
+  
+    // 親カテゴリーが変わったら
+      $('#category-wraps').on('change','#category-select', function(){
+        var parent_id = $(this).val();
+        $.ajax({
+          url: "/items/category_find",
+          type: "GET",
+          dataType: 'json',
+          data: {
+            category_id: parent_id
+          }
+        })
+        .done(function(children){
+          $("#child-wrap").show();
+          $('.child-option').remove();
+          $("#grandchild-wrap").hide();
+          $('.grandchild-option').remove();
+          children.forEach(function(child){
+            appendChildOptions(child)
+          })
+        });
+  
+      });
+    // 子カテゴリーが変わったら
+      $('#category-wraps').on('change', '#child-select', function(){
+        var parent_id = $(this).val();
+        $.ajax({
+          url: "/items/category_find",
+          type: "GET",
+          dataType: 'json',
+          data: {
+            category_id: parent_id
+          }
+        })
+        .done(function(children){
+          $("#grandchild-wrap").show();
+          $('.grandchild-option').remove();
+          children.forEach(function(child){
+            appendGrandChildOptions(child)
+          })
+        });
+  
+      });
+    // 孫カテゴリーが変わったら
+      $('#category-wraps').on('change', '#grandchild-select', function(){
+        var child_id = $('#child-select').val();
+        if (child_id < 380){
+          $("#brand-wrap").show();
+  
+        }else{
+          $('#brand-wrap').hide();
+        }
+      });
+  
+  
+    // 検索結果を押したら
+  
+  
+      $(".sell-form-box").on('change', '#condition-select', function(){
+        $("#delivery-method-wrap").show();
+      });
+  
+  
+      $(".sell-form-box").on('keyup', "#price-input", function(){
+        let price = $(this).val();
+        let fee = price * 0.1
+        let fee_to_i = parseInt(fee);
+        let added_comma_fee = fee_to_i.toLocaleString();
+        var profit = price - fee_to_i
+        var added_comma_profit =profit.toLocaleString();
+        if (price >= 300 && price <= 9999999) {
+          $("#fee").html("¥" + added_comma_fee);
+          $("#profit").html("¥" + added_comma_profit);
+        }else {
+          $("#fee").empty();
+          $("#profit").empty();
+        };     
+      }) 
     
+    
+
+
+  }
+
+  // 商品出品ページ用のjs
+
+  else{
     $("#brand-wrap").show();
     $("#child-wrap").show();
     $("#grandchild-wrap").show();
@@ -93,97 +186,5 @@ $(function(){
       });
     });
 
-
-
-  }
-
-  // 商品出品ページ用のjs
-
-  else{
-
-    $("#brand-wrap").hide();
-    $("#child-wrap").hide();
-    $("#grandchild-wrap").hide();
-    $("#delivery-method-wrap").hide();
-
-
-
-  // 親カテゴリーが変わったら
-    $('#category-wraps').on('change','#category-select', function(){
-      var parent_id = $(this).val();
-      $.ajax({
-        url: "/items/category_find",
-        type: "GET",
-        dataType: 'json',
-        data: {
-          category_id: parent_id
-        }
-      })
-      .done(function(children){
-        $("#child-wrap").show();
-        $('.child-option').remove();
-        $("#grandchild-wrap").hide();
-        $('.grandchild-option').remove();
-        children.forEach(function(child){
-          appendChildOptions(child)
-        })
-      });
-
-    });
-  // 子カテゴリーが変わったら
-    $('#category-wraps').on('change', '#child-select', function(){
-      var parent_id = $(this).val();
-      $.ajax({
-        url: "/items/category_find",
-        type: "GET",
-        dataType: 'json',
-        data: {
-          category_id: parent_id
-        }
-      })
-      .done(function(children){
-        $("#grandchild-wrap").show();
-        $('.grandchild-option').remove();
-        children.forEach(function(child){
-          appendGrandChildOptions(child)
-        })
-      });
-
-    });
-  // 孫カテゴリーが変わったら
-    $('#category-wraps').on('change', '#grandchild-select', function(){
-      var child_id = $('#child-select').val();
-      if (child_id < 380){
-        $("#brand-wrap").show();
-
-      }else{
-        $('#brand-wrap').hide();
-      }
-    });
-
-
-  // 検索結果を押したら
-
-
-    $(".sell-form-box").on('change', '#condition-select', function(){
-      $("#delivery-method-wrap").show();
-    });
-
-
-    $(".sell-form-box").on('keyup', "#price-input", function(){
-      let price = $(this).val();
-      let fee = price * 0.1
-      let fee_to_i = parseInt(fee);
-      let added_comma_fee = fee_to_i.toLocaleString();
-      var profit = price - fee_to_i
-      var added_comma_profit =profit.toLocaleString();
-      if (price >= 300 && price <= 9999999) {
-        $("#fee").html("¥" + added_comma_fee);
-        $("#profit").html("¥" + added_comma_profit);
-      }else {
-        $("#fee").empty();
-        $("#profit").empty();
-      };     
-    }) 
   }
 });

--- a/app/assets/javascripts/item/category.js
+++ b/app/assets/javascripts/item/category.js
@@ -102,7 +102,7 @@ $(function(){
 
   // 商品出品ページ用のjs
 
-  else{
+  else if(window.location.href.match(/\/items\/\d+\/edit/)){
     $("#brand-wrap").show();
     $("#child-wrap").show();
     $("#grandchild-wrap").show();
@@ -186,5 +186,7 @@ $(function(){
       });
     });
 
+  }else{
+    return false
   }
 });

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -28,26 +28,65 @@
           overflow: hidden;
           .owl-stage {
             width: 300px;
+            position: relative;
             left: 0;
             .owl-item {
               width: 300px;
-              .owl-item-inner {
+              float: left;
+              &__inner {
+                min-height: 300px;
                 position: relative;
                 width: 100%;
                 height: 0;
                 padding: 0 0 100%;
-                .owl-lazy {
-                  width: 100%;
-                  vertical-align: bottom;
+
+                img{
+                  position: absolute;
+                  top: 0;
+                  left: 0;
+                  right: 0;
+                  width: auto;
+                  height: 100%;
+                  margin: auto;
                 }
               }
             }
           }
         }
-        .owl-nav.disabled {
+        .disabled {
           display: none;
         }
-      }
+        .owl-dots {
+            line-height: 0;
+
+          .owl-dot{
+            width: 60px;
+            height: 60px;
+            max-height: none;
+            position: relative;
+            overflow: hidden;
+            display: inline-block;
+            width: 20%;
+            max-height: 90px;
+            opacity: .4;
+            cursor: pointer;
+            &.active{
+              opacity: 1;
+              cursor: default;
+            }
+            &__inner{
+              position: static;
+              width: auto;
+              height: auto;
+              padding: 0;
+              img {
+                width: 100%;
+                vertical-align: bottom;
+              }
+            } 
+          }
+        }
+      }       
     }
     .visible-sp {
       display: none;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,22 +6,22 @@ class ItemsController < ApplicationController
 
   def index 
     if user_signed_in?
-      @items = Item.where.not(user_id:current_user.id,status:4)
-      @chanel_items = Brand.search("シャネル").items.where.not(user_id:current_user.id,status:4).limit(10)
-      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(user_id:current_user.id,status:4).limit(10)
-      @supreme_items = Brand.search("スプリーム").items.where.not(user_id:current_user.id,status:4).limit(10)
-      @nike_items = Brand.search("ナイキ").items.where.not(user_id:current_user.id,status:4).limit(10)
+      @items = Item.where.not(user_id:current_user.id,status:4).order(id: "DESC")
+      @chanel_items = Brand.search("シャネル").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
+      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
+      @supreme_items = Brand.search("スプリーム").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
+      @nike_items = Brand.search("ナイキ").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
     else
       @items = Item.where.not(status:4)
-      @chanel_items = Brand.search("シャネル").items.where.not(status:4).limit(10)
-      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(status:4).limit(10)
-      @supreme_items = Brand.search("スプリーム").items.where.not(status:4).limit(10)
-      @nike_items = Brand.search("ナイキ").items.where.not(status:4).limit(10)
+      @chanel_items = Brand.search("シャネル").items.where.not(status:4).limit(10).order(id: "DESC")
+      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(status:4).limit(10).order(id: "DESC")
+      @supreme_items = Brand.search("スプリーム").items.where.not(status:4).limit(10).order(id: "DESC")
+      @nike_items = Brand.search("ナイキ").items.where.not(status:4).limit(10).order(id: "DESC")
     end
-    @ladies_items = @items.get_ladies.limit(10)
-    @mens_items = @items.get_mens.limit(10)
-    @electronics_items = @items.get_electronics.limit(10)
-    @hobbies_items = @items.get_hobbies.limit(10)
+    @ladies_items = @items.get_ladies.limit(10).order(id: "DESC")
+    @mens_items = @items.get_mens.limit(10).order(id: "DESC")
+    @electronics_items = @items.get_electronics.limit(10).order(id: "DESC")
+    @hobbies_items = @items.get_hobbies.limit(10).order(id: "DESC")
   end
 
   def category_find

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,23 +5,15 @@ class ItemsController < ApplicationController
 
 
   def index 
-    if user_signed_in?
-      @items = Item.where.not(user_id:current_user.id,status:4).order(id: "DESC")
-      @chanel_items = Brand.search("シャネル").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
-      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
-      @supreme_items = Brand.search("スプリーム").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
-      @nike_items = Brand.search("ナイキ").items.where.not(user_id:current_user.id,status:4).limit(10).order(id: "DESC")
-    else
-      @items = Item.where.not(status:4)
-      @chanel_items = Brand.search("シャネル").items.where.not(status:4).limit(10).order(id: "DESC")
-      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(status:4).limit(10).order(id: "DESC")
-      @supreme_items = Brand.search("スプリーム").items.where.not(status:4).limit(10).order(id: "DESC")
-      @nike_items = Brand.search("ナイキ").items.where.not(status:4).limit(10).order(id: "DESC")
-    end
-    @ladies_items = @items.get_ladies.limit(10).order(id: "DESC")
-    @mens_items = @items.get_mens.limit(10).order(id: "DESC")
-    @electronics_items = @items.get_electronics.limit(10).order(id: "DESC")
-    @hobbies_items = @items.get_hobbies.limit(10).order(id: "DESC")
+    id = user_signed_in? ? current_user.id : nil
+    @ladies_items = Item.get_ladies.buyable(id).recent10
+    @mens_items = Item.get_mens.buyable(id).recent10
+    @electronics_items = Item.get_electronics.buyable(id).recent10
+    @hobbies_items = Item.get_hobbies.buyable(id).recent10
+    @chanel_items = Brand.buyable_items("シャネル", id).recent10
+    @louisvuitton_items = Brand.buyable_items("ルイヴィトン", id).recent10
+    @supreme_items = Brand.buyable_items("スプリーム", id).recent10
+    @nike_items = Brand.buyable_items("ナイキ", id).recent10
   end
 
   def category_find
@@ -131,18 +123,7 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def image_params
-  #   params.require(:images).to_h
-  # end
 
-  def image_params
-    params.require(:images).map do |u|
-      ActionController::Parameters.new(u.to_h).permit(:image)
-    end
-  end
 
-  def set_category
-    
-  end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,21 +7,21 @@ class ItemsController < ApplicationController
   def index 
     if user_signed_in?
       @items = Item.where.not(user_id:current_user.id,status:4)
-      @chanel_items = Brand.search("シャネル").items.where.not(user_id:current_user.id,status:4)
-      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(user_id:current_user.id,status:4)
-      @supreme_items = Brand.search("スプリーム").items.where.not(user_id:current_user.id,status:4)
-      @nike_items = Brand.search("ナイキ").items.where.not(user_id:current_user.id,status:4)
+      @chanel_items = Brand.search("シャネル").items.where.not(user_id:current_user.id,status:4).limit(10)
+      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(user_id:current_user.id,status:4).limit(10)
+      @supreme_items = Brand.search("スプリーム").items.where.not(user_id:current_user.id,status:4).limit(10)
+      @nike_items = Brand.search("ナイキ").items.where.not(user_id:current_user.id,status:4).limit(10)
     else
       @items = Item.where.not(status:4)
-      @chanel_items = Brand.search("シャネル").items.where.not(status:4)
-      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(status:4)
-      @supreme_items = Brand.search("スプリーム").items.where.not(status:4)
-      @nike_items = Brand.search("ナイキ").items.where.not(status:4)
+      @chanel_items = Brand.search("シャネル").items.where.not(status:4).limit(10)
+      @louisvuitton_items = Brand.search("ルイヴィトン").items.where.not(status:4).limit(10)
+      @supreme_items = Brand.search("スプリーム").items.where.not(status:4).limit(10)
+      @nike_items = Brand.search("ナイキ").items.where.not(status:4).limit(10)
     end
-    @ladies_items = @items.get_ladies
-    @mens_items = @items.get_mens
-    @electronics_items = @items.get_electronics
-    @hobbies_items = @items.get_hobbies
+    @ladies_items = @items.get_ladies.limit(10)
+    @mens_items = @items.get_mens.limit(10)
+    @electronics_items = @items.get_electronics.limit(10)
+    @hobbies_items = @items.get_hobbies.limit(10)
   end
 
   def category_find

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -196,18 +196,20 @@ class SignupController < ApplicationController
       town: session[:town],
       building: session[:building]
     )
-    if @user.save
-      @@card[:user_id] = @user.id
-      @@card.save
-      @address[:user_id] = @user.id
-      @address.save
-      reset_session
-      session[:user_id] = @user.id
-      sign_in(@user)
-      redirect_to root_path(@user)
-    else
-      render '/signup/social_choice'
-    end
+    @user.save
+    redirect_to root_path
+    # if @user.save
+    #   @@card[:user_id] = @user.id
+    #   @@card.save
+    #   @address[:user_id] = @user.id
+    #   @address.save
+    #   reset_session
+    #   session[:user_id] = @user.id
+    #   sign_in(@user)
+    #   redirect_to root_path(@user)
+    # else
+    #   render '/signup/social_choice'
+    # end
   end
 
   def logout

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -9,7 +9,13 @@ class Brand < ApplicationRecord
 
   def self.search(brand_name)
     return nil if brand_name == ""
-    @brand = Brand.find_by(name: brand_name)
+    brand = Brand.find_by(name: brand_name)
+  end
+
+  def self.buyable_items(name, id)
+    return nil if name == ""
+    brand = Brand.find_by(name: name)
+    buyable_items = brand.items.buyable(id)
   end
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
   validates :days, presence: {message: "選択してください"}
   validates :prefecture_id, numericality: {greater_than: 0, message: "選択してください" }
   validates :price, numericality: {greater_than_or_equal_to: 300, less_than_or_qual_to: 9999999, message: "300以上9999999以下で入力してください" }
+  validate :brand_present, on: :update_brand
   belongs_to :user, class_name: "User"
   belongs_to :buyer, class_name: "User", optional: true
   belongs_to :category
@@ -105,6 +106,11 @@ class Item < ApplicationRecord
     children = Category.find_by(name: "おもちゃ・ホビー・グッズ").children
     hobbies_items = get_category_items(range(children))
   end
+
+  def update_brand(id)
+    self.update(brand_id: id)
+  end
+
   
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -58,7 +58,15 @@ class Item < ApplicationRecord
     購入済み:4,
   }
 
+  def self.buyable(id)
+    if id == nil
+      where.not(status: 4)
+    else
+      where.not(user_id: id, status: 4)
+    end
+  end
 
+  scope :recent10, -> { order(created_at: :desc).limit(10)}
   scope :get_category_items, -> (category_id) {where(category_id: category_id)}
 
   def reject_images(attributes)

--- a/app/models/validators/brand_validation.rb
+++ b/app/models/validators/brand_validation.rb
@@ -1,0 +1,15 @@
+
+class BrandValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value =~ 
+      record.errors[attribute] << (options[:message] || "はメールアドレスではありません")
+    end
+  end
+end
+ 
+class Item < ApplicationRecord
+  validates :email, presence: true, email: true
+end
+
+
+

--- a/app/views/items/_detail.html.haml
+++ b/app/views/items/_detail.html.haml
@@ -2,16 +2,20 @@
   .item-photo
     .owl-carousel__loaded__drag
       .owl-stage-outer
-        .owl-stage
-          .owl-item
-            .owl-item-inner
-              = image_tag item.images.first.image, class: 'owl-lazy'
+        .owl-stage{style: "left:0px;width:#{300*item.images.length}px"}
+          -item.images.each do |image|
+            .owl-item{style: "width:300px"}
+              .owl-item__inner
+                = image_tag image.image, class: 'owl-lazy'
       .owl-nav.disabled
         .owl-prev prev
         .owl-next next
-      .owl-dots.disabled
-        .owl-dot
-          %span
+      .owl-dots
+        -item.images.each do |image|
+          .owl-dot
+            %span
+            .owl-dot__inner
+              = image_tag image.image
   %section.visible-sp
     .item-btn-float-area
     = link_to "#", class:"item-buy-btn" do

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -106,6 +106,10 @@
           - else
             %input{name: "brand_name", id: "brand-select", class: "select-default", placeholder: "例）シャネル"}
             %ul{id: 'brands-search-list'}
+      - if item.errors[:brand_id].any?
+        %ul.error-text
+          - item.errors[:brand_id].each do |message|
+            %li= message  
       .form-group
         =f.label :condition do
           商品の状態

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -18,8 +18,8 @@
         %li.step4-progress-distance__li
           完了
           .ball-end
-
-  = form_for @user, url: card_new_signup_index_path, method: :get, class: 'first-main__box' do |f|
+  -# = form_for @user, url: card_new_signup_index_path, method: :get, class: 'first-main__box' do |f|
+  = form_for @user, url: complete_signup_index_path, method: :get, class: 'first-main__box' do |f|
     .step4-block
       .step4-block-up
         %b 発送元・お届け先住所入力

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,9 @@ ActiveRecord::Schema.define(version: 20191211093411) do
     t.datetime "updated_at",                                null: false
     t.integer  "category_id"
     t.integer  "brand_id"
+    t.integer  "buyer_id"
     t.index ["brand_id"], name: "index_items_on_brand_id", using: :btree
+    t.index ["buyer_id"], name: "index_items_on_buyer_id", using: :btree
     t.index ["category_id"], name: "index_items_on_category_id", using: :btree
     t.index ["name"], name: "index_items_on_name", using: :btree
     t.index ["user_id"], name: "index_items_on_user_id", using: :btree


### PR DESCRIPTION
# what
1 トップページに表示される商品をブランド、カテゴリーごとに１０個限定にする
2 新規登録でクレジット登録を求められないようにする。
3 Itemコントローラーのスリム化
4 ブランドのバリデーション
https://i.gyazo.com/56b1ee9fdc6da90e8fec3ac240228513.png
5 カルーセルの実装
https://i.gyazo.com/a3fdeb61665443422ca0eb4db0ceca43.mp4
# why
1 商品の表示が多すぎてもしょうがない
2 ローカルで開発を続けるのをスムーズにするため
3 重複した記述を減らすため
4 ユーザーがブランド入力に手間取らないように
5 複数投稿した画像が全て詳細画面で見られるように